### PR TITLE
Add nREPL evaluation status bar indicator

### DIFF
--- a/src/nrepl/events.ts
+++ b/src/nrepl/events.ts
@@ -1,0 +1,13 @@
+interface Event {
+    type: string
+}
+
+export class NReplEvaluationStartedEvent implements Event {
+    type = "started"
+    constructor(public fileName: string, public filePath: string){}
+}
+
+export class NReplEvaluationFinishedEvent implements Event {
+    type = "finished";
+    constructor(public fileName: string, public filePath: string, public error?:string){}
+}

--- a/src/statusbar/cljs-build.ts
+++ b/src/statusbar/cljs-build.ts
@@ -2,7 +2,7 @@ import { window, StatusBarAlignment, StatusBarItem } from "vscode";
 import * as state from '../state';
 import * as util from '../utilities';
 
-export class CljsBuildStatusBar {
+export class CljsBuildStatusBarItem {
     private statusBarItem: StatusBarItem;
     constructor(alignment: StatusBarAlignment) {
         this.statusBarItem = window.createStatusBarItem(alignment);

--- a/src/statusbar/connection.ts
+++ b/src/statusbar/connection.ts
@@ -3,7 +3,7 @@ import configReader from "../configReader";
 import * as state from '../state';
 import * as util from '../utilities';
 
-export class ConnectionStatusBar {
+export class ConnectionStatusBarItem {
     private statusBarItem: StatusBarItem;
 
     constructor(alignment: StatusBarAlignment) {

--- a/src/statusbar/file-type.ts
+++ b/src/statusbar/file-type.ts
@@ -1,13 +1,38 @@
 import { window, StatusBarAlignment, StatusBarItem } from "vscode";
 import { activeReplWindow } from '../repl-window';
+
+import { onNReplEvent } from "../nrepl";
+import { NReplEvaluationStartedEvent, NReplEvaluationFinishedEvent } from "../nrepl/events";
+
 import configReader from "../configReader";
 import * as state from '../state';
 import * as util from '../utilities';
 
+export interface EvaluationError {
+    fileName: string;
+    filePath: string;
+    message: string;
+}
+
 export class FileTypeStatusBarItem {
     private statusBarItem: StatusBarItem;
+
+    private activeEvals = new Array<string>();
+
+    private errors = new Array<EvaluationError>();
+
+    private get isEvaluating() {
+        return this.activeEvals.length > 0;
+    }
+
+    private get hasErrors(){
+        return this.errors.length > 0;
+    }
+
     constructor(alignment: StatusBarAlignment) {
         this.statusBarItem = window.createStatusBarItem(alignment);
+        // TODO: Event handling and resulting state should be moved to global state
+        onNReplEvent(this.handleNreplEvent);
     }
 
     update() {
@@ -23,19 +48,22 @@ export class FileTypeStatusBarItem {
 
         if(connected) {
             if (fileType == 'cljc' && sessionType !== null && !activeReplWindow()) {
-                text = "cljc/" + sessionType;
+                text = this.statusTextDecorator("cljc/" + sessionType);
                 if (util.getSession('clj') !== null && util.getSession('cljs') !== null) {
                     command = "calva.toggleCLJCSession";
                     tooltip = `Click to use ${(sessionType === 'clj' ? 'cljs' : 'clj')} REPL for cljc`;
                 }
             } else if (sessionType === 'cljs') {
-                text = "cljs";
+                text = this.statusTextDecorator("cljs");
                 tooltip = "Connected to ClojureScript REPL";
             } else if (sessionType === 'clj') {
-                text = "clj";
+                text = this.statusTextDecorator("clj");
                 tooltip = "Connected to Clojure REPL";
             }
-            color = configReader.colors.typeStatus;
+            color = this.connectedStatusColor();
+            if(this.hasErrors) {
+                tooltip = this.errorTooltip();
+            }
         }
 
         this.statusBarItem.command = command;
@@ -43,6 +71,70 @@ export class FileTypeStatusBarItem {
         this.statusBarItem.tooltip = tooltip;
         this.statusBarItem.color = color
         this.statusBarItem.show();
+    }
+
+    private statusTextDecorator(text): string {
+        if(this.hasErrors) {
+            const c = this.errors.length;
+            text = `${text} $(alert) ${c > 1 ? c : ""}`
+        }
+        if(this.isEvaluating) {
+            text = text + " $(gear~spin)";
+        }
+        return text;
+    }
+
+    private connectedStatusColor(): string {
+        const c = configReader.colors;
+        if(this.hasErrors) {
+            return c.error;
+        } else if (this.isEvaluating) {
+            return c.launching;
+        }
+        return c.typeStatus;
+    }
+
+    private errorTooltip(): string {
+        if(this.errors.length > 1){
+            return "There are errors in multiple files";
+        }
+        const err = this.errors[0];
+        return `Error: ${err.fileName}: ${err.message}`;
+    }
+
+    private handleNreplEvent = (e: NReplEvaluationStartedEvent | NReplEvaluationFinishedEvent) => {
+        switch(e.type){
+            case "started":
+                this.removeError(e.filePath);
+                this.activeEvals.push(e.filePath);
+                break;
+            case "finished":
+                this.removeActive(e.filePath);
+                const fe = <NReplEvaluationFinishedEvent> e;
+                if(fe.error) {
+                    this.errors.push({
+                        fileName: fe.fileName,
+                        filePath: fe.filePath,
+                        message: fe.error
+                    });
+                }
+                break;
+        }
+        this.update();
+    }
+
+    private removeActive(filePath: string) {
+        const idx = this.activeEvals.indexOf(filePath);
+        if(idx !== -1) {
+            this.activeEvals.splice(idx, 1);
+        }
+    }
+
+    private removeError(filePath: string) {
+        const idx = this.errors.findIndex(e => e.filePath === filePath);
+        if(idx !== -1) {
+            this.errors.splice(idx, 1);
+        }
     }
 
     dispose() {

--- a/src/statusbar/file-type.ts
+++ b/src/statusbar/file-type.ts
@@ -4,7 +4,7 @@ import configReader from "../configReader";
 import * as state from '../state';
 import * as util from '../utilities';
 
-export class TypeStatusBar {
+export class FileTypeStatusBarItem {
     private statusBarItem: StatusBarItem;
     constructor(alignment: StatusBarAlignment) {
         this.statusBarItem = window.createStatusBarItem(alignment);

--- a/src/statusbar/index.ts
+++ b/src/statusbar/index.ts
@@ -1,16 +1,16 @@
 import { StatusBarAlignment } from "vscode";
-import { TypeStatusBar } from "./typeStatusBar";
-import { PrettyPrintStatusBar } from "./prettyPrintStatusBar";
-import { CljsBuildStatusBar } from "./cljsBuildStatusBar";
-import { ConnectionStatusBar } from "./connectionStatusBar";
+import { FileTypeStatusBarItem } from "./file-type";
+import { PrettyPrintStatusBarItem } from "./pretty-print";
+import { CljsBuildStatusBarItem } from "./cljs-build";
+import { ConnectionStatusBarItem } from "./connection";
 
 const statusBarItems = [];
 
 function init(): any[] {
-    statusBarItems.push(new ConnectionStatusBar(StatusBarAlignment.Left));
-    statusBarItems.push(new TypeStatusBar(StatusBarAlignment.Left));
-    statusBarItems.push(new CljsBuildStatusBar(StatusBarAlignment.Left));
-    statusBarItems.push(new PrettyPrintStatusBar(StatusBarAlignment.Right));
+    statusBarItems.push(new ConnectionStatusBarItem(StatusBarAlignment.Left));
+    statusBarItems.push(new FileTypeStatusBarItem(StatusBarAlignment.Left));
+    statusBarItems.push(new CljsBuildStatusBarItem(StatusBarAlignment.Left));
+    statusBarItems.push(new PrettyPrintStatusBarItem(StatusBarAlignment.Right));
     update();
     return statusBarItems;
 }

--- a/src/statusbar/pretty-print.ts
+++ b/src/statusbar/pretty-print.ts
@@ -2,7 +2,7 @@ import { window, StatusBarAlignment, StatusBarItem } from "vscode";
 import configReader from "../configReader";
 import * as state from '../state';
 
-export class PrettyPrintStatusBar {
+export class PrettyPrintStatusBarItem {
     private statusBarItem: StatusBarItem;
     constructor(alignment: StatusBarAlignment) {
         this.statusBarItem = window.createStatusBarItem(alignment);


### PR DESCRIPTION
<!-- ❤️ Thanks for filing a Pull Request on Calva! You are contributing to a better Clojure coding experience. ❤️ -->
<!-- We use checklists in order to not forget about important lessons we and others have learnt along the way. -->

## What has Changed?
<!-- Introduce the change(s) briefly here. Consider explaining why a particular change was implemented the way it was. If you have considered alternative ways to introduce the change, please elaborate a bit on that as well. -->
- Add nREPL evaluation event emitter
- Add nREPL evaluation status to the `typeStatusBar`

![Screen Shot 2019-11-24 at 12 24 29 PM](https://user-images.githubusercontent.com/4265922/69500999-6a174200-0eb5-11ea-822e-166352937a6f.png)
![Screen Shot 2019-11-24 at 12 23 57 PM](https://user-images.githubusercontent.com/4265922/69501000-6a174200-0eb5-11ea-979b-19ca1a162980.png)
![Screen Shot 2019-11-24 at 12 24 15 PM](https://user-images.githubusercontent.com/4265922/69501001-6aafd880-0eb5-11ea-9bcc-ebd7939e4fee.png)

This is very much WIP.  I re-evaluated [my previous approach](https://github.com/BetterThanTomorrow/calva/pull/480) and saw some short comings.  I think what I have here is a good start, but there is still work left to do.

#### Emitting events from nREPL
I added an event emitter and am emitting events from an nREPL session.  Only the start and finish success/error are implemented.  Maybe it would be better to manage the event emitter from inside the client, I'm not sure.

#### Evaluation State
Right now the evaluation events are being consumed directly by the status bar.  It would make more sense to manage this in the global state, but there lacks a mechanism to push state change events from the state to the subscribers, such as status bar.

#### Note on state management
I did notice there is a `to-do` item related to state management:
`Get better control of Calva state.`
For this, I can make a recommendation.  This doesn't apply to all applications, but I think it would make a lot of sense in Calva to implement a Redux store.  This will improve on the current implementation of the global state and reduce cross dependencies on the different components.  This wouldn't need to be applied to everything, just in the truly global state.  I could put together a POC in a separate PR if interested.

### TODO
- Move event handling to global state
- Add client connect/disconnect events
- Clear evaluation state on disconnect


<!-- Tell us what Github issue(s) your PR is fixing. Consider creating the issue if need be. -->
Fixes #

## My Calva PR Checklist
<!-- Remove the checkboxes that do not apply, as Github reports how many are not ticked. If you want to add checkboxes, please do. -->

I have:

- [ ] Read [How to Contribute](https://github.com/BetterThanTomorrow/calva/wiki/How-to-Contribute#before-sending-pull-requests).
- [ ] Made sure I am directing this pull request at the `dev` branch. (Or have specific reasons to target some other branch.)
- [ ] Made sure I am changed the default PR base branch, so that it is not `master`. (Sorry for the nagging.)
- [ ] Tested the VSIX built from the PR (well, if this is a PR that changes the source code.) You'll find the artifacts by clicking _Show all checks_ in the CI section of the PR page, and then _Details_ on the `ci/circleci: build` test. (For now you'll need to opt in to the CircleCI _New Experience_ UI to see the Artifacts tab, because bug.)
     - [ ] Tested the particular change
     - [ ] Figured if the change might have some side effects and tested those as well.
     - [ ] Smoke tested the extension as such.
- [ ] Referenced the issue I am fixing/addressing _in a commit message for the pull request_.
     - [ ] If I am fixing the issue, I have used [GitHub's fixes/closes syntax](https://help.github.com/en/articles/closing-issues-using-keywords)
     - [ ] If I am fixing just part of the issue, I have just referenced it w/o any of the "fixes” keywords.
- [ ] Created the issue I am fixing/addressing, if it was not present.
- [ ] Updated the `[Unreleased]` entry in `CHANGELOG.md`, linking the issue(s) that the PR is addressing.

## The Calva Team PR Checklist:
<!-- Please read the list, since you'll get a better idea about what to expect by doing so. 😄 -->

Before merging we (at least one of us) have:

- [ ] Made sure the PR is directed at the `dev` branch (unless reasons).
- [ ] Read the source changes.
- [ ] Given feedback and guidance on source changes, if needed. (Please consider noting extra nice stuff as well.)
- [ ] Tested the VSIX built from the PR (well, if this is a PR that changes the source code.)
     - [ ] Tested the particular change
     - [ ] Figured if the change might have some side effects and tested those as well.
     - [ ] Smoke tested the extension as such.
- [ ] If need be, had a chat within the team about particular changes.

Ping @pez, @kstehn, @cfehse

<!-- This is a nice book to read about the power of checklists: https://www.samuelthomasdavies.com/book-summaries/health-fitness/the-checklist-manifesto/ -->